### PR TITLE
feat: Add current team lineup section

### DIFF
--- a/index.html
+++ b/index.html
@@ -664,6 +664,55 @@
           </div>
         </section>
       </section>
+      <section id="current-lineup">
+        <h2 class="section-title">Alineación Actual</h2>
+        <div class="lineup-grid">
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Courtois">
+            <h3>Courtois</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Trent">
+            <h3>Trent</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Asencio">
+            <h3>Asencio</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Huijsen">
+            <h3>Huijsen</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Fran García">
+            <h3>Fran García</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Valverde">
+            <h3>Valverde</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/tch.jpg" alt="Tchouameni">
+            <h3>Tchouameni</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Bellingham">
+            <h3>Bellingham</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Rodrygo">
+            <h3>Rodrygo</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Gonzalo">
+            <h3>Gonzalo</h3>
+          </div>
+          <div class="player-card">
+            <img src="./assets/img/placeholder_player.png" alt="Vinicius">
+            <h3>Vinicius</h3>
+          </div>
+        </div>
+      </section>
     </div>
     <div class="footer-links">
       <div class="footer-container">

--- a/styles.css
+++ b/styles.css
@@ -381,6 +381,53 @@ ul{
     color: #ffffff;
 }
 
+/* Current Lineup Section */
+#current-lineup .section-title {
+  text-align: center;
+  font-size: 2.5rem; /* Or match other section titles */
+  margin-top: 40px;
+  margin-bottom: 30px;
+  color: #333; /* Or match other titles */
+}
+
+.lineup-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); /* Responsive grid */
+  gap: 20px;
+  padding: 20px;
+  justify-items: center; /* Center items in their grid cells */
+}
+
+.player-card {
+  background-color: #f9f9f9; /* Light background for the card */
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 15px;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  width: 100%; /* Ensure card takes full width of grid cell */
+  max-width: 200px; /* Optional: constrain max width of a card if minmax allows too much growth */
+}
+
+.player-card img {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%; /* Circular images */
+  object-fit: cover; /* Cover the area, crop if necessary */
+  margin-bottom: 10px;
+  background-color: #ddd; /* Visible if image fails to load (placeholder) */
+  border: 2px solid #ccc; /* Border for the placeholder */
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.player-card h3 {
+  font-size: 1.2rem;
+  color: #333;
+  margin-top: 5px;
+}
+
 /*Goleadores en resolución menor a 1075*/
 @media only screen and (max-width:1075px)
 {


### PR DESCRIPTION
I've added a new section to display the current team lineup below the Champions carousel.

- I modified `index.html` to include a new `<section id="current-lineup">`.
  - The section features a title "Alineación Actual".
  - Player cards are arranged in a `div.lineup-grid`.
  - Each player card contains an image (Tchouameni's actual image, placeholders for others) and the player's name.
- I updated `styles.css` to add styling for the new section:
  - Styles for the section title, player grid, individual player cards, player images (including visual styling for placeholders), and player names.
  - The player grid is responsive.